### PR TITLE
Csl deck list feed and my deck list

### DIFF
--- a/sylvanapi/views/auth.py
+++ b/sylvanapi/views/auth.py
@@ -25,9 +25,11 @@ def login_user(request):
     # If authentication was successful, respond with their token
     if authenticated_user is not None:
         token = Token.objects.get(user=authenticated_user)
+        player = Player.objects.get(pk=authenticated_user.id)
         data = {
             'valid': True,
-            'token': token.key
+            'token': token.key,
+            'id':  player.id
         }
         return Response(data)
     else:
@@ -62,6 +64,6 @@ def register_user(request):
     # Use the REST Framework's token generator on the new user account
     token = Token.objects.create(user=player.user)
     # Return the token to the client
-    data = { 'token': token.key }
+    data = { 'token': token.key, 'id': player.id }
     return Response(data, status=status.HTTP_201_CREATED)
 

--- a/sylvanapi/views/deck.py
+++ b/sylvanapi/views/deck.py
@@ -106,7 +106,7 @@ class DeckViewSet(ViewSet):
             deck.power_level = request.data["powerLevel"]
             deck.primer = request.data["primer"]
             deck.player = player
-
+                                #
             play_style = PlayStyle.objects.get(pk=request.data["playStyle"]["id"])
             deck.play_style = play_style
             deck.save()

--- a/sylvanapi/views/player.py
+++ b/sylvanapi/views/player.py
@@ -6,7 +6,7 @@ from sylvanapi.models import Player
 
 
 class PlayerView(ViewSet):
-    """SHOTGUN APP USERS VIEW"""
+    """ Players VIEW"""
 
     def retrieve(self, request, pk):
         """Handle GET requests for single player
@@ -29,7 +29,7 @@ class PlayerView(ViewSet):
         return Response(serializer.data)
     
 class PlayerSerializer(serializers.ModelSerializer):
-    """JSON serializer for app users
+    """JSON serializer for players
     """
     class Meta:
         model = Player

--- a/sylvanapi/views/player.py
+++ b/sylvanapi/views/player.py
@@ -1,0 +1,37 @@
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from sylvanapi.models import Player
+
+
+
+class PlayerView(ViewSet):
+    """SHOTGUN APP USERS VIEW"""
+
+    def retrieve(self, request, pk):
+        """Handle GET requests for single player
+        Returns:
+            Response -- JSON serialized player
+        """
+        
+        player = Player.objects.get(pk=pk)
+        serializer = PlayerSerializer(player)
+        return Response(serializer.data)
+        
+
+    def list(self, request):
+        """Handle GET requests to get all app players
+        Returns:
+            Response -- JSON serialized list of app players
+        """
+        player = Player.objects.all()
+        serializer = PlayerSerializer(player, many=True)
+        return Response(serializer.data)
+    
+class PlayerSerializer(serializers.ModelSerializer):
+    """JSON serializer for app users
+    """
+    class Meta:
+        model = Player
+        fields = "__all__"
+        depth = 3

--- a/sylvanserving/urls.py
+++ b/sylvanserving/urls.py
@@ -3,13 +3,14 @@ from django.conf.urls import include
 from django.urls import path
 from sylvanapi.views.auth import register_user, login_user
 from rest_framework import routers
-
 from sylvanapi.views.deck import DeckViewSet
+from sylvanapi.views.player import PlayerView
 
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'decks', DeckViewSet, 'deck')
-
+router.register(r'players', PlayerView, 'player')
+router.register(r'MyDeckList', PlayerView, 'MyDeckList')
 urlpatterns = [
     path('', include(router.urls)),
     path('register', register_user),


### PR DESCRIPTION
Issues: #21 Users should be able to view a list of all of the decks they created when they click on the My Decks tab of the Nav bar
Issue: #2 Navbar functionality 
Issue: #9 Users should be able to view a list of all users' submitted deck lists when they click on the Deck List Feed tab of the Nav bar 

Changes:
- Changed the views/auth so that when a new user registers, their playerId is stored in local storage so that I can reference that 
   to get the currently logged in user which I can then use to filter decks by a specific user 
- Fixed an error I was having by using bracket notation to get the playStyle Id with:
  play_style = PlayStyle.objects.get(pk=request.data["playStyle"]["id"]
- Created PlayerView in player.py 

Added two routes to urls.py : 
router.register(r'players', PlayerView, 'player')
router.register(r'MyDeckList', PlayerView, 'MyDeckList')

Tested in postman and also by serving to the browser and using the devtools to ensure I was getting back the appropriate data  as well as visually inspecting the page rendering only the decks created by the currently logged in user