### PR TITLE
csl-DeckForm

### DIFF
--- a/sylvanapi/views/deck.py
+++ b/sylvanapi/views/deck.py
@@ -16,7 +16,7 @@ class DeckViewSet(ViewSet):
         """
         
         player = Player.objects.get(user=request.auth.user)
-        play_style = PlayStyle.objects.get(pk=request.data["playStyle"]["id"])
+        play_style = PlayStyle.objects.get(pk=request.data["playStyle"])
        
         # Create a new Python instance of the Deck class
         # and set its properties from what was sent in the

--- a/sylvanapi/views/playStyle.py
+++ b/sylvanapi/views/playStyle.py
@@ -1,0 +1,48 @@
+"""View module for handling requests about game types"""
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from sylvanapi.models import PlayStyle
+
+
+class PlayStyleView(ViewSet):
+    """Sylvan API PlayStyles"""
+
+    def retrieve(self, request, pk=None):
+        """Handle GET requests for single game type
+
+        Returns:
+            Response -- JSON serialized game type
+        """
+        try:
+            playStyle = PlayStyle.objects.get(pk=pk)
+            serializer = PlayStyleSerializer(playStyle, context={'request': request})
+            return Response(serializer.data)
+        except Exception as ex:
+            return HttpResponseServerError(ex)
+
+    def list(self, request):
+        """Handle GET requests to get all game types
+
+        Returns:
+            Response -- JSON serialized list of game types
+        """
+        playStyles = PlayStyle.objects.all()
+
+        # Note the additional `many=True` argument to the
+        # serializer. It's needed when you are serializing
+        # a list of objects instead of a single object.
+        serializer = PlayStyleSerializer(
+            playStyles, many=True, context={'request': request})
+        return Response(serializer.data)
+    
+class PlayStyleSerializer(serializers.ModelSerializer):
+    """JSON serializer for game types
+
+    Arguments:
+        serializers
+    """
+    class Meta:
+        model = PlayStyle
+        fields = "__all__"

--- a/sylvanserving/urls.py
+++ b/sylvanserving/urls.py
@@ -4,6 +4,7 @@ from django.urls import path
 from sylvanapi.views.auth import register_user, login_user
 from rest_framework import routers
 from sylvanapi.views.deck import DeckViewSet
+from sylvanapi.views.playStyle import PlayStyleView
 from sylvanapi.views.player import PlayerView
 
 
@@ -11,6 +12,8 @@ router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'decks', DeckViewSet, 'deck')
 router.register(r'players', PlayerView, 'player')
 router.register(r'MyDeckList', PlayerView, 'MyDeckList')
+router.register(r'playStyle', PlayStyleView, 'playStyle')
+
 urlpatterns = [
     path('', include(router.urls)),
     path('register', register_user),


### PR DESCRIPTION
Issue: #3 User should be able to fill out a form to create a new deck 

- Added route to urls
- Created PlayStyle view 
- took off [id] from the create method 

Turns out when testing in postman I was inputting the playstyle in a different way than the client side was sending so I needed to take off the [id] to successfully post the new deck 

Tested in both postman and the client side and confirmed that the  new deck was being successfully posted to the database and rendering correctly in the deck list feed and the user's list of created decks 
