### PR TITLE
csl-fixedDeleteRerenderForMyDecks

### DIFF
--- a/sylvanapi/views/deck.py
+++ b/sylvanapi/views/deck.py
@@ -57,7 +57,9 @@ class DeckViewSet(ViewSet):
         play_style = self.request.query_params.get('type', None)
         if play_style is not None:
             decks = decks.filter(play_style__id=play_style)
-        
+        playerId = self.request.query_params.get('playerId', None)
+        if playerId is not None:
+            decks = decks.filter(player_id = playerId)
         serializer = DeckSerializer(decks, many=True, context={'request': request})
         return Response(serializer.data)
     

--- a/sylvanapi/views/event.py
+++ b/sylvanapi/views/event.py
@@ -86,12 +86,13 @@ class EventView(ViewSet):
         """
         events = Event.objects.all()
         player = Player.objects.get(user=request.auth.user)
+        organizer = Player.objects.get(user=request.auth.user)
+        organizer.save()
         
         # Set the `joined` property on every event
         for event in events:
     # Check to see if the player is in the attendees list on the event
             event.joined = player in event.attendees.all()
-
                
         serializer = EventSerializer(events, many=True)
         return Response(serializer.data)
@@ -109,21 +110,22 @@ class EventView(ViewSet):
         player = Player.objects.get(user=request.auth.user)
         event = Event.objects.get(pk=pk)
         event.attendees.add(player)
-        return Response({'message': 'Gamer added'}, status=status.HTTP_201_CREATED)
+        return Response({'message': 'Player added'}, status=status.HTTP_201_CREATED)
     
     @action(methods=['delete'], detail=True)
     def leave(self, request, pk):
-        """Post request for a user to sign up for an event"""
+        """Post request for a user to leave an event"""
     
         player = Player.objects.get(user=request.auth.user)
         event = Event.objects.get(pk=pk)
         event.attendees.remove(player)
-        return Response({'message': 'Gamer removed'}, status=status.HTTP_204_NO_CONTENT)
+        return Response({'message': 'Player removed'}, status=status.HTTP_204_NO_CONTENT)
 
 class EventSerializer(serializers.ModelSerializer):
     """JSON serializer for game types
     """
     class Meta:
         model = Event
-        fields = ("__all__")
+        fields = ('id', 'description', 'date', 'time', 'address', 'venue', 'joined', 'attendees', 'name', 'organizer')
         depth = 2
+        


### PR DESCRIPTION
Issue: 
When clicking the delete button on the MyDecksList on the front end it would not rerender the up to date list without refreshing the page

Modified: Deck.py and Event.py 

Deck.py:
-Originally was filtering decks for MyDecks on the front end but it was causing problems after you deleted a deck from the list. 
 Changed the filtering to the list method on the back end which prevented the issues. 

Event.py:
- Added organizer to the eventserializer and list method so I could display it on the frontend 



